### PR TITLE
use GITHUB_TOKEN; update vignette

### DIFF
--- a/.github/workflows/basic_checks.yaml
+++ b/.github/workflows/basic_checks.yaml
@@ -64,6 +64,6 @@ jobs:
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: docs # The folder the action should deploy.

--- a/vignettes/HOWTO_BUILD_WORKSHOP.Rmd
+++ b/vignettes/HOWTO_BUILD_WORKSHOP.Rmd
@@ -75,6 +75,7 @@ remain encrypted until you use them in a workflow.
 See [Creating and storing encrypted secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets)
 
 - `DOCKER_USERNAME`: your dockerhub username; create a dockerhub account if you do not have one
-- `DOCKER_PASSWORD`: your dockerhub password
-- Github `ACCESS_TOKEN`: a [github personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). Make sure that your personal access token contains `repo` permissions (all of them). 
+- `DOCKER_PASSWORD`: your dockerhub password or an access token obtained from [Docker Hub][]
+
+[Docker Hub]: https://hub.docker.com/settings/security
 


### PR DESCRIPTION
@seandavi 
I think users don't have to generate an `ACCESS_TOKEN`, they can use the `GITHUB_TOKEN` instead.
I've updated the vignette accordingly with a minor change in the `DOCKER_PASSWORD` options.