### PR TITLE
Use CRAN mirror to install deps

### DIFF
--- a/.github/workflows/basic_checks.yaml
+++ b/.github/workflows/basic_checks.yaml
@@ -32,6 +32,8 @@ jobs:
           
       - name: Install dependencies
         run: |
+          options(repos = c(CRAN = "https://cran.r-project.org"))
+          BiocManager::repositories()
           remotes::install_deps(dependencies = TRUE, repos = BiocManager::repositories())
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}


### PR DESCRIPTION
This avoids binary package installations that are causing several problems (eg for igraph, Rcpp)